### PR TITLE
Feedeen の SSL サイト (https://www.feedeen.com) への対応パッチです。

### DIFF
--- a/extractors/extractor.feedeen.tbrl.js
+++ b/extractors/extractor.feedeen.tbrl.js
@@ -3,7 +3,7 @@
 //   "name"        : "Extractor for Feedeen"
 // , "description" : "Extract an article on Feedeen"
 // , "include"     : ["content"]
-// , "match"       : ["*://feedeen.com/*"]
+// , "match"       : ["*://feedeen.com/*", "*://*.feedeen.com/*"]
 // , "version"     : "0.0.4"
 // , "downloadURL" : "https://raw.github.com/YungSang/patches-for-taberareloo/master/extractors/extractor.feedeen.tbrl.js"
 // }
@@ -17,7 +17,7 @@
     {
       name: 'Feedeen',
       getItem: function (ctx, getOnly) {
-        if (!ctx.href.match(/\/\/feedeen.com\/d/)) {
+        if (!ctx.href.match(/\/\/(?:www\.)?feedeen.com\/d/)) {
           return null;
         }
 
@@ -45,7 +45,7 @@
 
     {
       name: 'Quote - Feedeen',
-      ICON: 'http://feedeen.com/favicon.ico',
+      ICON: 'https://www.feedeen.com/favicon.ico',
       check: function (ctx) {
         return Extractors.Feedeen.getItem(ctx, true) && ctx.selection;
       },
@@ -57,7 +57,7 @@
 
     {
       name: 'ReBlog - Feedeen',
-      ICON: 'http://feedeen.com/favicon.ico',
+      ICON: 'https://www.feedeen.com/favicon.ico',
       check: function (ctx) {
         var item = Extractors.Feedeen.getItem(ctx, true);
         return item && (
@@ -72,7 +72,7 @@
 
     {
       name: 'Photo - Feedeen',
-      ICON: 'http://feedeen.com/favicon.ico',
+      ICON: 'https://www.feedeen.com/favicon.ico',
       check: function (ctx) {
         return Extractors.Feedeen.getItem(ctx, true) && ctx.onImage;
       },
@@ -84,7 +84,7 @@
 
     {
       name: 'Link - Feedeen',
-      ICON: 'http://feedeen.com/favicon.ico',
+      ICON: 'https://www.feedeen.com/favicon.ico',
       check: function (ctx) {
         return Extractors.Feedeen.getItem(ctx, true);
       },
@@ -99,7 +99,7 @@
     name  : 'Feedeen + Taberareloo',
     check : function () {
       var key = TBRL.config.post.shortcutkey_ldr_plus_taberareloo;
-      if (/^https?:\/\/feedeen.com\/d/.test(location.href) && TBRL.config.post.ldr_plus_taberareloo && key) {
+      if (/^https?:\/\/(?:www\.)?feedeen.com\/d/.test(location.href) && TBRL.config.post.ldr_plus_taberareloo && key) {
         this.key = key;
         return true;
       } else {


### PR DESCRIPTION
こんにちは、 Feedeen を運営している、伊藤と申します。
TaberarelooのFeedeen対応パッチを開発・配布していただき、ありがとうございます。

直前のお知らせで申し訳ないのですが、明日（9/8）より、SSL対応サイトへの強制リダイレクトのため、FeedeenのURLが変更になります（ http://feedeen.com/ → https://www.feedeen.com/ ）。この変更に対応するための pull req を作成しましたので、お手すきのときに適用していただければ幸いです。

拡張類の動作に支障があるというのに気付いておらず、お知らせが遅れてしまいました。お手数をおかけしますが、よろしくお願いいたします。
